### PR TITLE
Fix Event Name Not Set

### DIFF
--- a/libraries/csharp_dotnetcore/Microsoft.Bot.Builder.Adapters.WeChat/Microsoft.Bot.Builder.Adapters.WeChat.csproj
+++ b/libraries/csharp_dotnetcore/Microsoft.Bot.Builder.Adapters.WeChat/Microsoft.Bot.Builder.Adapters.WeChat.csproj
@@ -20,7 +20,7 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="AdaptiveCards.Rendering.Html" Version="1.1.2" />
+    <PackageReference Include="AdaptiveCards.Rendering.Html" Version="1.2.3" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.1.0" />
     <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.5.1" />
     <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.5.1" />

--- a/libraries/csharp_dotnetcore/Microsoft.Bot.Builder.Adapters.WeChat/Microsoft.Bot.Builder.Adapters.WeChat.csproj
+++ b/libraries/csharp_dotnetcore/Microsoft.Bot.Builder.Adapters.WeChat/Microsoft.Bot.Builder.Adapters.WeChat.csproj
@@ -20,7 +20,7 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="AdaptiveCards.Rendering.Html" Version="1.2.3" />
+    <PackageReference Include="AdaptiveCards.Rendering.Html" Version="1.2.4" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.1.0" />
     <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.5.1" />
     <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.5.1" />

--- a/libraries/csharp_dotnetcore/Microsoft.Bot.Builder.Adapters.WeChat/WeChatMessageMapper.cs
+++ b/libraries/csharp_dotnetcore/Microsoft.Bot.Builder.Adapters.WeChat/WeChatMessageMapper.cs
@@ -15,8 +15,8 @@ using Microsoft.Bot.Builder.Adapters.WeChat.Helpers;
 using Microsoft.Bot.Builder.Adapters.WeChat.Schema;
 using Microsoft.Bot.Builder.Adapters.WeChat.Schema.JsonResults;
 using Microsoft.Bot.Builder.Adapters.WeChat.Schema.Requests;
+using Microsoft.Bot.Builder.Adapters.WeChat.Schema.Requests.Events;
 using Microsoft.Bot.Builder.Adapters.WeChat.Schema.Responses;
-using Microsoft.Bot.Connector;
 using Microsoft.Bot.Schema;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -346,11 +346,12 @@ namespace Microsoft.Bot.Builder.Adapters.WeChat
                 activity.Id = requestMessage.MsgId.ToString(CultureInfo.InvariantCulture);
                 activity.Type = ActivityTypes.Message;
             }
-            else
+            else if (wechatRequest is RequestEvent eventRequest)
             {
                 // Event message don't have Id;
                 activity.Id = Guid.NewGuid().ToString();
                 activity.Type = ActivityTypes.Event;
+                activity.Name = eventRequest.EventType;
             }
 
             return activity;


### PR DESCRIPTION
Fix: https://github.com/microsoft/BotFramework-WeChat/issues/16
1. Set WeChat event type as event activty name.
2. Update adaptive card package version to 1.2.4
