### PR TITLE
Add method for manual refresh the access token

### DIFF
--- a/libraries/csharp_dotnetcore/Microsoft.Bot.Builder.Adapters.WeChat/WeChatClient.cs
+++ b/libraries/csharp_dotnetcore/Microsoft.Bot.Builder.Adapters.WeChat/WeChatClient.cs
@@ -110,11 +110,12 @@ namespace Microsoft.Bot.Builder.Adapters.WeChat
         /// <summary>
         /// Get access token used to call WeChat API.
         /// </summary>
+        /// <param name="forceRefresh">Force refresh the access token.</param>
         /// <returns>Access token string.</returns>
-        public virtual async Task<string> GetAccessTokenAsync()
+        public virtual async Task<string> GetAccessTokenAsync(bool forceRefresh = false)
         {
             var token = await _tokenStorage.GetAsync(_settings.AppId).ConfigureAwait(false);
-            if (token == null)
+            if (token == null || forceRefresh)
             {
                 var url = GetAccessTokenEndPoint(_settings.AppId, _settings.AppSecret);
                 var bytes = await SendHttpRequestAsync(HttpMethod.Get, url).ConfigureAwait(false);

--- a/libraries/csharp_dotnetcore/Microsoft.Bot.Builder.Adapters.WeChat/WeChatHttpAdapter.cs
+++ b/libraries/csharp_dotnetcore/Microsoft.Bot.Builder.Adapters.WeChat/WeChatHttpAdapter.cs
@@ -51,6 +51,17 @@ namespace Microsoft.Bot.Builder.Adapters.WeChat
         }
 
         /// <summary>
+        /// Get access token depends on the current settings.
+        /// </summary>
+        /// <param name="forceRefresh">If force refresh the token.</param>
+        /// <returns>The access token string.</returns>
+        public async Task<string> GetWeChatAccessToken(bool forceRefresh)
+        {
+            var accessToken = await _wechatClient.GetAccessTokenAsync(forceRefresh).ConfigureAwait(false);
+            return accessToken;
+        }
+
+        /// <summary>
         /// Standard BotBuilder adapter method to delete a previous message.
         /// </summary>
         /// <param name="turnContext">A TurnContext representing the current incoming message and environment.</param>

--- a/libraries/csharp_dotnetcore/tests/Microsoft.Bot.Builder.Adapters.WeChat.Tests/TestUtilities/MockDataUtility.cs
+++ b/libraries/csharp_dotnetcore/tests/Microsoft.Bot.Builder.Adapters.WeChat.Tests/TestUtilities/MockDataUtility.cs
@@ -724,7 +724,7 @@ namespace Microsoft.Bot.Builder.Adapters.WeChat.Tests
             var wechatClient = new Mock<WeChatClient>(WeChatSettings, storage, null);
             var result = JsonConvert.SerializeObject(WeChatJsonResult);
             var byteResult = Encoding.UTF8.GetBytes(result);
-            wechatClient.Setup(c => c.GetAccessTokenAsync()).Returns(Task.FromResult("mockToken"));
+            wechatClient.Setup(c => c.GetAccessTokenAsync(false)).Returns(Task.FromResult("mockToken"));
             wechatClient.Setup(c => c.SendHttpRequestAsync(It.IsAny<HttpMethod>(), It.IsAny<string>(), It.IsAny<object>(), It.IsAny<string>(), It.IsAny<int>())).Returns(Task.FromResult(byteResult));
             wechatClient.Setup(c => c.UploadMediaAsync(It.IsAny<AttachmentData>(), It.IsAny<bool>(), It.IsAny<int>())).Returns(Task.FromResult(MockTempMediaResult(MediaTypes.Image)));
             wechatClient.Setup(c => c.UploadNewsAsync(It.IsAny<News[]>(), It.IsAny<bool>(), It.IsAny<int>())).Returns(Task.FromResult(MockTempMediaResult(MediaTypes.News)));


### PR DESCRIPTION
fix #17 
There is only one valid access token for a service account, need to expose the refresh interface when access token is refreshed out of the WeChatAdapter.