### PR TITLE
Add double checked locking when get and update access token

### DIFF
--- a/libraries/csharp_dotnetcore/Microsoft.Bot.Builder.Adapters.WeChat/Schema/JsonResults/UploadMediaResult.cs
+++ b/libraries/csharp_dotnetcore/Microsoft.Bot.Builder.Adapters.WeChat/Schema/JsonResults/UploadMediaResult.cs
@@ -2,10 +2,12 @@
 
 namespace Microsoft.Bot.Builder.Adapters.WeChat.Schema.JsonResults
 {
-    public class UploadMediaResult : WeChatJsonResult
+    public class UploadMediaResult : WeChatJsonResult, IStoreItem
     {
         [JsonProperty("media_id")]
         public string MediaId { get; set; }
+
+        public string ETag { get; set; }
 
         public virtual bool Expired() => false;
     }

--- a/libraries/csharp_dotnetcore/Microsoft.Bot.Builder.Adapters.WeChat/Schema/WeChatAccessToken.cs
+++ b/libraries/csharp_dotnetcore/Microsoft.Bot.Builder.Adapters.WeChat/Schema/WeChatAccessToken.cs
@@ -5,7 +5,7 @@ using System;
 
 namespace Microsoft.Bot.Builder.Adapters.WeChat.Schema
 {
-    public class WeChatAccessToken
+    public class WeChatAccessToken : IStoreItem
     {
         public WeChatAccessToken()
         {
@@ -19,5 +19,7 @@ namespace Microsoft.Bot.Builder.Adapters.WeChat.Schema
         public string Secret { get; set; }
 
         public DateTimeOffset ExpireTime { get; set; }
+
+        public string ETag { get; set; }
     }
 }

--- a/libraries/csharp_dotnetcore/Microsoft.Bot.Builder.Adapters.WeChat/Storage/AccessTokenStorage.cs
+++ b/libraries/csharp_dotnetcore/Microsoft.Bot.Builder.Adapters.WeChat/Storage/AccessTokenStorage.cs
@@ -45,7 +45,8 @@ namespace Microsoft.Bot.Builder.Adapters.WeChat.Storage
                 var keys = new string[] { key };
                 var result = await _storage.ReadAsync<WeChatAccessToken>(keys, cancellationToken).ConfigureAwait(false);
                 result.TryGetValue(key, out var wechatResult);
-                if (wechatResult == null || wechatResult.ExpireTime.ToUnixTimeSeconds() <= DateTimeOffset.UtcNow.ToUnixTimeSeconds())
+
+                if (IfTokenExpired(wechatResult))
                 {
                     return null;
                 }
@@ -89,6 +90,22 @@ namespace Microsoft.Bot.Builder.Adapters.WeChat.Storage
                     _semaphore = null;
                 }
             }
+        }
+
+        private bool IfTokenExpired(WeChatAccessToken tokenResult)
+        {
+            if (tokenResult == null)
+            {
+                return true;
+            }
+
+            // Return true when token is nearly expired.
+            if (tokenResult.ExpireTime.ToUnixTimeSeconds() - DateTimeOffset.UtcNow.ToUnixTimeSeconds() <= 10)
+            {
+                return true;
+            }
+
+            return false;
         }
     }
 }

--- a/libraries/csharp_dotnetcore/Microsoft.Bot.Builder.Adapters.WeChat/WeChatClient.cs
+++ b/libraries/csharp_dotnetcore/Microsoft.Bot.Builder.Adapters.WeChat/WeChatClient.cs
@@ -158,6 +158,7 @@ namespace Microsoft.Bot.Builder.Adapters.WeChat
             {
                 var uploadResult = await UploadMediaAsync(attachmentData, url, isTemporary, timeout).ConfigureAwait(false);
                 CheckWeChatApiResponse(uploadResult);
+                uploadResult.ETag = "*";
                 await _attachmentStorage.SaveAsync(mediaHash, uploadResult).ConfigureAwait(false);
                 return uploadResult;
             }
@@ -181,6 +182,7 @@ namespace Microsoft.Bot.Builder.Adapters.WeChat
                 var url = await GetAcquireMediaUrlEndPoint().ConfigureAwait(false);
                 var uploadResult = await UploadMediaAsync(attachmentData, url, false, timeout).ConfigureAwait(false);
                 CheckWeChatApiResponse(uploadResult);
+                uploadResult.ETag = "*";
                 await _attachmentStorage.SaveAsync(mediaHash, uploadResult).ConfigureAwait(false);
                 return uploadResult;
             }
@@ -218,6 +220,7 @@ namespace Microsoft.Bot.Builder.Adapters.WeChat
                 }
 
                 CheckWeChatApiResponse(uploadResult);
+                uploadResult.ETag = "*";
                 await _attachmentStorage.SaveAsync(mediaHash, uploadResult).ConfigureAwait(false);
                 return uploadResult;
             }
@@ -726,6 +729,7 @@ namespace Microsoft.Bot.Builder.Adapters.WeChat
                 Secret = _settings.AppSecret,
                 ExpireTime = DateTimeOffset.UtcNow.AddSeconds(tokenResult.ExpireIn),
                 Token = tokenResult.Token,
+                ETag = "*",
             };
             await _tokenStorage.SaveAsync(_settings.AppId, newToken).ConfigureAwait(false);
             return newToken;


### PR DESCRIPTION
Add double checked locking to reduce the time cost and ensure only one valid access token at the same time.