### PR TITLE
change message menu from string to number

### DIFF
--- a/samples/csharp_dotnetcore/Microsoft.Bot.Builder.Adapters.WeChat.TestBot/Resources/MessageMenu.json
+++ b/samples/csharp_dotnetcore/Microsoft.Bot.Builder.Adapters.WeChat.TestBot/Resources/MessageMenu.json
@@ -1,14 +1,13 @@
 {
-  "head_content": "Are you satisfied with this service?",
-  "list": [
-    {
-      "id": "101",
-      "content": "Satisfied"
-    },
-    {
-      "id": "102",
-      "content": "NotSatisfied"
-    }
-  ],
-  "tail_content": "You are welcome to come back again."
+    "head_content": "Are you satisfied with this service?",
+    "list": [{
+            "id": 101,
+            "content": "Satisfied"
+        },
+        {
+            "id": 102,
+            "content": "NotSatisfied"
+        }
+    ],
+    "tail_content": "You are welcome to come back again."
 }


### PR DESCRIPTION
Fix #47 

WeChat will ignore the id in message menu when set it to string.
It will be the default int value from 101 with no exception.

Type msgmenu will be used in ChannlData which is dynamic, change the sample bot message menu id to int should be enough.

