### PR TITLE
Install later NuGet version for WeChat pipelines

### DIFF
--- a/build/botframework-wechat-dotnet.yml
+++ b/build/botframework-wechat-dotnet.yml
@@ -53,10 +53,8 @@ steps:
 - powershell: 'gci env:* | sort-object name | Format-Table -AutoSize -Wrap'
   displayName: 'Display env vars'
 
-- task: NuGetToolInstaller@0
-  displayName: 'Use NuGet 4.9.1'
-  inputs:
-    versionSpec: 4.9.1
+- task: NuGetToolInstaller@1
+  displayName: 'Use NuGet '
 
 - task: NuGetCommand@2
   displayName: 'NuGet restore'

--- a/build/dotnet-build-steps.yml
+++ b/build/dotnet-build-steps.yml
@@ -8,10 +8,8 @@ steps:
     tags: 'Version=$(ReleasePackageVersion)'
   continueOnError: true
 
-- task: NuGetToolInstaller@0
-  displayName: 'Use NuGet 4.9.1'
-  inputs:
-    versionSpec: 4.9.1
+- task: NuGetToolInstaller@1
+  displayName: 'Use NuGet '
 
 - task: NuGetCommand@2
   displayName: 'NuGet restore'


### PR DESCRIPTION
Nuget being used was 4.9.1. Now it's 5.8.0.

This fixes the errors:
##[error]C:\Program Files\dotnet\sdk\5.0.100\Sdks\Microsoft.NET.Sdk\targets\Microsoft.PackageDependencyResolution.targets(241,5): Error NETSDK1005: Assets file 'D:\a\1\s\libraries\Microsoft.Bot.Builder.Dialogs.Adaptive\obj\project.assets.json' doesn't have a target for 'netstandard2.0'. Ensure that restore has run and that you have included 'netstandard2.0' in the TargetFrameworks for your project.

Apparently brought on by a new version of msbuild being used.